### PR TITLE
style: 限制最大宽度& 折叠friends

### DIFF
--- a/components/Blogger.vue
+++ b/components/Blogger.vue
@@ -1,9 +1,16 @@
 <script setup>
-import { computed } from 'vue'
+import { computed,ref } from 'vue'
 import VPTeamMembersItem from './BloggerItem.vue'
 const size = 'small'
 const props= {friends:(await (await fetch("https://ghproxy.com/https://raw.githubusercontent.com/NX-Official/friends-link-plus/main/output/friends.json")).json()).friends}
-const members =  props.friends
+const isMore = ref(false)
+const members =  computed(() => {
+  if (isMore.value) {
+    return props.friends
+  } else {
+    return props.friends.slice(0, 5)
+  }
+})
 const classes = computed(() => [
   size ?? 'medium',
   `count-${members.length}`
@@ -15,6 +22,9 @@ const classes = computed(() => [
     <div class="container">
       <div v-for="member in members" :key="member.name" class="item">
         <VPTeamMembersItem :size="size" :member="member" />
+      </div>
+      <div v-if="!isMore">
+        <VPTeamMembersItem :blank="true" @click="isMore=true"/>
       </div>
     </div>
   </div>

--- a/components/BloggerItem.vue
+++ b/components/BloggerItem.vue
@@ -2,7 +2,8 @@
 
 defineProps({
   size: String,
-  member: Object
+  member: Object,
+  blank: Boolean
 })
 
 const goUrl = (url) => {
@@ -13,7 +14,7 @@ const goUrl = (url) => {
 
 <template>
   <article class="VPTeamMembersItem" :class="[size ?? 'medium']">
-    <div class="profile" @click="goUrl(member.url)">
+    <div class="profile" @click="goUrl(member.url)" v-if="!blank">
       <figure class="avatar">
         <img class="avatar-img" :src="member.avatar" :alt="member.name">
       </figure>
@@ -41,6 +42,7 @@ const goUrl = (url) => {
         </div>
       </div>
     </div>
+    <div class="profile" v-else><div class="more">More..</div></div>
   </article>
 </template>
 
@@ -60,7 +62,8 @@ const goUrl = (url) => {
 }
 
 .VPTeamMembersItem.small .data {
-  padding-top: 20px;
+  padding-top: 10px;
+  width: 100px;
 }
 
 .VPTeamMembersItem.small .avatar {
@@ -157,10 +160,14 @@ const goUrl = (url) => {
   object-fit: cover;
 }
 
-.author_name {
+.author_name,.more {
   margin: 0;
   font-weight: 600;
   cursor: pointer;
+}
+
+.more{
+  color: var(--vp-c-text-2);
 }
 
 .affiliation {


### PR DESCRIPTION
本次更新的内容主要为

1. 使friends组件头像对齐(但是名字信息不能对其捏，要不然失去了响应性
2. 当friends过多时进行折叠，目前最少显示5个

![image](https://github.com/camera-2018/hdu-cs-wiki/assets/49270362/21e994d1-446b-455f-a5f6-7e28783abdbd)


欢迎前来学习
